### PR TITLE
Bug Fix when screen orientation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,19 @@ Fix: The image clip retains its last position when screen orientation changes.
 <h1>Gradle dependency</h1>
 
 ```groovy        
+//ORIGINAL
 //add this to your top level build.gradle file
  maven { url 'https://dl.bintray.com/kandroid/maven' }
  
 //and add this to your module level build.gradle file
   compile 'com.github.developer--:beforeafterslider:1.0.4'
+  
+  //MY VERSION
+  //add this to your top level build.gradle file
+			maven { url 'https://jitpack.io' }
+      
+//and add this to your module level build.gradle file
+	    implementation 'com.github.blackfox94:before_after_slider:701e3d5861'
 ```
 
 <h1><a href="https://github.com/ioramashvili/BeforeAfterSlider"> iOS version</a> </h1>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The library uses Glide for image loading
 
 ---------------------------------------------------------
 
-The image clip retains its last position when screen orientation changes.
+Fix: The image clip retains its last position when screen orientation changes.
 
 ---------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 </p>
 The library uses Glide for image loading
 
+---------------------------------------------------------
+
+The image clip retains its last position when screen orientation changes.
+
+---------------------------------------------------------
+
 ```java
   <com.github.developer__.BeforeAfterSlider
         android:id="@+id/mySlider"

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Fix: The image clip retains its last position when screen orientation changes.
 //and add this to your module level build.gradle file
   compile 'com.github.developer--:beforeafterslider:1.0.4'
   
-  //MY VERSION
-  //add this to your top level build.gradle file
-			maven { url 'https://jitpack.io' }
+//MY VERSION
+//add this to your top level build.gradle file
+  maven { url 'https://jitpack.io' }
       
 //and add this to your module level build.gradle file
-	    implementation 'com.github.blackfox94:before_after_slider:701e3d5861'
+  implementation 'com.github.blackfox94:before_after_slider:701e3d5861'
 ```
 
 <h1><a href="https://github.com/ioramashvili/BeforeAfterSlider"> iOS version</a> </h1>

--- a/beforeafterslider/src/main/java/com/github/developer__/asycn/ClipDrawableProcessorTask.kt
+++ b/beforeafterslider/src/main/java/com/github/developer__/asycn/ClipDrawableProcessorTask.kt
@@ -30,7 +30,7 @@ class ClipDrawableProcessorTask<T>(imageView: ImageView, seekBar: SeekBar, priva
     override fun doInBackground(vararg args: T): ClipDrawable? {
         Looper.myLooper()?.let { Looper.prepare() }
         try {
-            var theBitmap : Bitmap
+            var theBitmap: Bitmap
             if (args[0] is String) {
                 theBitmap = Glide.with(context)
                         .load(args[0])
@@ -74,13 +74,16 @@ class ClipDrawableProcessorTask<T>(imageView: ImageView, seekBar: SeekBar, priva
             if (clipDrawable != null) {
                 initSeekBar(clipDrawable)
                 imageRef.get().setImageDrawable(clipDrawable)
-                val progressNum = 5000
-                clipDrawable.level = progressNum
+                if (clipDrawable.level != 0) {
+                    val progressNum = 5000
+                    clipDrawable.level = progressNum
+                } else
+                    clipDrawable.level = seekBarRef.get().progress
                 loadedFinishedListener?.onLoadedFinished(true)
-            }else {
+            } else {
                 loadedFinishedListener?.onLoadedFinished(false)
             }
-        }else {
+        } else {
             loadedFinishedListener?.onLoadedFinished(false)
         }
     }


### PR DESCRIPTION
I fixed a bug that happened when the screen orientation changed.
The slider would retain it's position whereas the image would be split in the middle again, creating an offset between the 2 images and the slider.

Now if the screen orientation changes the image will remain split where it was before the screen rotation happened.